### PR TITLE
use number of languages after sorting

### DIFF
--- a/script.js
+++ b/script.js
@@ -51,8 +51,8 @@ $( document ).ready(function() {
         languages.push(obj.language)
       }
     });
-    var maxNumberOfLanguages = getMaxLanguages(languages);
     var languagesSorted = languages.byCount();
+    var maxNumberOfLanguages = getMaxLanguages(languagesSorted);
 
     for (var i = 0; i < maxNumberOfLanguages; i++) {
       var languagesOutput;


### PR DESCRIPTION
This avoids undefied leaking into report when the maxLanguages
is higher then the number of languages in the list.
