### PR TITLE
Add alt text to avatar image tag.

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ $( document ).ready(function() {
 
     // avatar pic
     var avatar = userResult.avatar_url;
-    $('.gh-avatar').html("<a href=" + profileURL + "><img src='" + avatar + "'></a>");
+    $('.gh-avatar').html("<a href=" + profileURL + "><img src='" + avatar + "' alt='github avatar'></a>");
 
     // get last activity month
     var ghMonth = parseInt(userResult.updated_at.substring(5,7));

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ $( document ).ready(function() {
 
     // avatar pic
     var avatar = userResult.avatar_url;
-    $('.gh-avatar').html("<a href=" + profileURL + "><img src='" + avatar + "' alt='github avatar'></a>");
+    $('.gh-avatar').html("<a href=" + profileURL + "><img src='" + avatar + "' alt='GitHub avatar'></a>");
 
     // get last activity month
     var ghMonth = parseInt(userResult.updated_at.substring(5,7));


### PR DESCRIPTION
In my daily Monkey Test It results, my site was failing the SEO section for missing an alt tag in the GitHub Report Card avatar image.

Failure report:
https://monkeytest.it/test/384e9945-7ca9-45de-9faa-be8631d2ba88

After this proposed change, it passes the test:
https://monkeytest.it/test/e3271529-e6fd-4063-a11f-49383bf55c31
